### PR TITLE
Python3への移行に向けたprint文の除去

### DIFF
--- a/mutation_util/mutation_filter.py
+++ b/mutation_util/mutation_filter.py
@@ -12,7 +12,7 @@ def filter_mutation_list(input_file, output_file, ebpval, fishpval, realignpval,
             # print meta data
             if not line.startswith("#chr"):
                 if line.startswith("#"):
-                    print >> hout, line.rstrip('\n')
+                    print(line.rstrip('\n'), file=hout)
                     continue
             # get header line
             header = line


### PR DESCRIPTION
dd48852 の変更でPython3への移行に向けた変更が加えられていますが、一部のコードにPython2の`print`文が含まれているため、Python3での実行時にその箇所が実行されるとエラーになるようです。

このPRでは、残っている`print`文を`print`関数に置き換えます。